### PR TITLE
Fixed crash for some files

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -22,8 +22,6 @@ VIDEO_CODED_TYPE = 'video'
 VIDEO_NOTE_CROP_OFFSET_PARAMS = 'abs(in_w-in_h)'
 VIDEO_NOTE_CROP_SIZE_PARAMS = 'min(in_w,in_h)'
 
-ATTACHMENT_FILE_ID_KEY = 'i'
-
 
 class OutputType:
     NONE = 'none'

--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,7 @@ import youtube_dl
 
 from analytics import Analytics, AnalyticsType
 from constants import (
-    MAX_PHOTO_FILESIZE_UPLOAD, VIDEO_CODEC_NAMES, VIDEO_CODED_TYPE, ATTACHMENT_FILE_ID_KEY,
+    MAX_PHOTO_FILESIZE_UPLOAD, VIDEO_CODEC_NAMES, VIDEO_CODED_TYPE,
     OutputType
 )
 from database import User
@@ -559,16 +559,17 @@ def message_answer_handler(update: Update, context: CallbackContext):
     callback_query = update.callback_query
     callback_data = json.loads(callback_query.data)
 
-    if not callback_data:
+    if callback_data is None:
         callback_query.answer()
 
         return
 
-    original_attachment_file_id = callback_data[ATTACHMENT_FILE_ID_KEY]
-
     message = update.effective_message
     chat_type = update.effective_chat.type
     bot = context.bot
+
+    attachment = message.effective_attachment
+    attachment_file_id = attachment.file_id
 
     message_id = message.message_id
     chat_id = message.chat.id
@@ -582,7 +583,7 @@ def message_answer_handler(update: Update, context: CallbackContext):
     if chat_type == Chat.PRIVATE:
         bot.send_chat_action(chat_id, ChatAction.TYPING)
 
-    input_file = bot.get_file(original_attachment_file_id)
+    input_file = bot.get_file(attachment_file_id)
     input_file_url = input_file.file_path
 
     probe = None

--- a/src/utils.py
+++ b/src/utils.py
@@ -15,7 +15,6 @@ from analytics import AnalyticsType
 from constants import (
     MAX_VIDEO_NOTE_LENGTH,
     VIDEO_NOTE_CROP_OFFSET_PARAMS, VIDEO_NOTE_CROP_SIZE_PARAMS,
-    ATTACHMENT_FILE_ID_KEY,
     OutputType
 )
 
@@ -60,9 +59,7 @@ def ensure_size_under_limit(size, limit, update: Update, context: CallbackContex
 
 def send_video(bot, chat_id, message_id, output_bytes, attachment, caption, chat_type):
     if chat_type == Chat.PRIVATE and attachment is not None:
-        data = {
-            ATTACHMENT_FILE_ID_KEY: attachment.file_id
-        }
+        data = {}
 
         button = InlineKeyboardButton('Rounded', callback_data=json.dumps(data))
         reply_markup = InlineKeyboardMarkup([[button]])


### PR DESCRIPTION
This was caused by long Telegram assigned file ids, which were over the
inline keyboard button's limit.